### PR TITLE
refactor: extract conventional commit logic into dedicated package

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -3,6 +3,7 @@ package release
 import (
 	"os"
 	"strings"
+	"release/pkg/conventionalcommit"
 
 	"gopkg.in/yaml.v3"
 )
@@ -16,6 +17,9 @@ type Config struct {
 	DryRun                  bool      `yaml:"dryRun"`
 	Verbose                 bool      `yaml:"verbose"`
 	AllowUncleanWorkingTree bool      `yaml:"allowUncleanWorkingTree"`
+	CommitMessage conventionalcommit.Config  `yaml:"commitMessage"`
+	MinorTypes              []string  `yaml:"minorTypes"`
+	PatchTypes              []string  `yaml:"patchTypes"`
 }
 
 type GitConfig struct {
@@ -36,6 +40,7 @@ var DefaultConfig = Config{
 		Author: "Release",
 		Email:  "release@example.com",
 	},
+	CommitMessage: conventionalcommit.DefaultConfig,
 }
 
 // ReplaceVersionPlaceholder replaces the {version} placeholder in the versionCommand with the actual version.

--- a/pkg/config_integration_test.go
+++ b/pkg/config_integration_test.go
@@ -1,8 +1,11 @@
 //go:build integration
+
 package release
 
 import (
 	"os"
+	"reflect"
+	"release/pkg/conventionalcommit"
 	"testing"
 )
 
@@ -70,9 +73,10 @@ versionCommand: "incrementVersion"
 			Email:  "releasebot@example.com",
 		},
 		VersionCommand: "incrementVersion",
+		CommitMessage: conventionalcommit.DefaultConfig,
 	}
 
-	if cfg != expected {
+	if !reflect.DeepEqual(cfg, expected) {
 		t.Errorf("LoadConfig returned unexpected result.\nExpected: %+v\nGot: %+v", expected, cfg)
 	}
 }

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -1,6 +1,10 @@
 package release
 
-import "testing"
+import (
+	"reflect"
+	"release/pkg/conventionalcommit"
+	"testing"
+)
 
 func TestParseConfig(t *testing.T)  {
 	configYaml := `releaseBranch: test-branch
@@ -19,6 +23,7 @@ versionCommand: "incrementVersion"`
 			Email:  "releasebot@example.com",
 		},
 		VersionCommand: "incrementVersion",
+		CommitMessage: conventionalcommit.DefaultConfig,
 	}
 
 	result, err := parseConfig([]byte(configYaml))
@@ -26,7 +31,7 @@ versionCommand: "incrementVersion"`
 		t.Fatalf("failed to parse example config: %v", err)
 	}
 
-	if result != expected {
+	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Changelog does not match expected output.\nExpected:\n%v\nGot:\n%v", expected, result)
 	}
 }

--- a/pkg/conventionalcommit/commit.go
+++ b/pkg/conventionalcommit/commit.go
@@ -1,0 +1,32 @@
+package conventionalcommit
+
+import (
+	"strings"
+	"regexp"
+)
+
+type ConventionalCommit struct {
+	Type string
+	Scope string
+	Description string
+	Breaking bool
+}
+
+func ParseMessage(msg string) ConventionalCommit {
+	lines := strings.Split(msg, "\n")
+	header := lines[0]
+
+	// Regex to match: type(scope)!: description
+	re := regexp.MustCompile(`^(\w+)(?:[\(\[]([^)\\]]+)[\)\]])?(!)?:\s*(.+)$`)
+	matches := re.FindStringSubmatch(header)
+
+	var cc ConventionalCommit
+	if len(matches) > 0 {
+		cc.Type = matches[1]
+		cc.Scope = matches[2] // may be empty
+		cc.Breaking = matches[3] == "!" || strings.Contains(msg, "BREAKING CHANGE")
+		cc.Description = matches[4]
+	}
+
+	return cc
+}

--- a/pkg/conventionalcommit/config.go
+++ b/pkg/conventionalcommit/config.go
@@ -1,0 +1,22 @@
+package conventionalcommit
+
+type Config struct {
+	MinorTypes []string
+	PatchTypes []string
+}
+
+var DefaultConfig = Config{
+	MinorTypes: defaultMinorTypes,
+	PatchTypes: defaultPatchTypes,
+}
+
+var defaultMinorTypes = []string{
+	"feat",
+	"feature",
+}
+
+var defaultPatchTypes = []string{
+	"fix",
+	"perf",
+	"performance",
+}

--- a/pkg/release.go
+++ b/pkg/release.go
@@ -49,7 +49,7 @@ func Release() {
 	currentVersion, commitsSinceRelease := getLatestRelease(repo, startingCommit, config.TagFormat)
 	log.Printf("current version is %s\n", currentVersion)
 
-	changeType := parseSemverChange(commitsSinceRelease)
+	changeType := aggregateSemverChange(config.CommitMessage, commitsSinceRelease)
 	if changeType == noop {
 		log.Fatalf("changes since last release are insufficient - cancelling release...")
 	}

--- a/pkg/semver.go
+++ b/pkg/semver.go
@@ -1,7 +1,8 @@
 package release
 
 import (
-	"strings"
+	"slices"
+	"release/pkg/conventionalcommit"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -18,25 +19,27 @@ func (s semverChange) String() string {
 	return [...]string{"n/a", "patch", "minor", "major"}[s]
 }
 
-func parseSemverChange(commits []*object.Commit) semverChange {
-	changeType := noop
+func aggregateSemverChange(commitConfig conventionalcommit.Config, commits []*object.Commit) semverChange {
+	aggregateChange := noop
 	for _, commit := range commits {
-		commitChangeType := parseCommitVersionChange(commit)
-		if commitChangeType > changeType {
-			changeType = commitChangeType
+		change := parseSemverChange(commitConfig, commit)
+		if change > aggregateChange {
+			aggregateChange = change
 		}
 	}
-	return changeType
+	return aggregateChange
 }
 
-
-func parseCommitVersionChange(commit *object.Commit) semverChange {
-	if strings.Contains(commit.Message, "fix") {
-		return patch
-	} else if strings.Contains(commit.Message, "feat") {
-		return minor
-	} else if strings.Contains(commit.Message, "BREAKING CHANGE") {
+func parseSemverChange(commitConfig conventionalcommit.Config, commit *object.Commit) semverChange {
+	cc := conventionalcommit.ParseMessage(commit.Message)
+	if cc.Breaking {
 		return major
+	} 	
+	if slices.Contains(commitConfig.MinorTypes, cc.Type) {
+	    return minor
+	}
+	if slices.Contains(commitConfig.PatchTypes, cc.Type) {
+	    return patch
 	}
 	return noop
 }

--- a/pkg/semver_test.go
+++ b/pkg/semver_test.go
@@ -2,28 +2,32 @@ package release
 
 import (
 	"testing"
+
+	"release/pkg/conventionalcommit"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-func TestParseSemanticVersionChangeType(t *testing.T) {
-	noopCommit := &object.Commit{Message: "chore: anything that"}
-	patchCommit := &object.Commit{Message: "fix: a patch change"}
-	minorCommit := &object.Commit{Message: "feat: a minor change"}
-	majorCommit := &object.Commit{Message: "BREAKING CHANGE: a major change"}
-
-	if got := parseCommitVersionChange(patchCommit); got != patch {
-		t.Errorf("expected patch, got %v", got)
+func TestCommitSemverChange(t *testing.T) {
+	tests := []struct {
+		name     string
+		message  string
+		expected semverChange
+	}{
+		{"noop", "chore: anything that", noop},
+		{"patch", "fix: a patch change", patch},
+		{"minor", "feat: a minor change", minor},
+		{"major", "feat!: something something", major},
+		{"multiline", "feat: this is a subject\n\nThis is the body and its got some length to it.", minor},
+		{"breaking change in footer", "fix: a patch change\n\nBREAKING CHANGE: dropped support for X", major},
+		{"fix type with breaking change footer", "fix: patch level subject\n\nBREAKING CHANGE: something incompatible", major},
 	}
 
-	if got := parseCommitVersionChange(minorCommit); got != minor {
-		t.Errorf("expected minor, got %v", got)
-	}
-
-	if got := parseCommitVersionChange(majorCommit); got != major {
-		t.Errorf("expected major, got %v", got)
-	}
-
-	if got := parseCommitVersionChange(noopCommit); got != noop {
-		t.Errorf("expected none, got %v", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commit := &object.Commit{Message: tt.message}
+			if got := parseSemverChange(conventionalcommit.DefaultConfig, commit); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Move commit parsing and config into pkg/conventionalcommit, exposing ParseMessage and a DefaultConfig. Update semver helpers and config to use the new package. Fix capture group indices in ParseMessage and swap manual loops for slices.Contains.